### PR TITLE
[MM-506] Actualizar revocación de delegados

### DIFF
--- a/__tests__/delegate_test.js
+++ b/__tests__/delegate_test.js
@@ -166,7 +166,6 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity.did,
         prefixAddedDid
       );
-      console.log(validatedDelegate)
       expect(validatedDelegate).toBeTruthy();
     });
 
@@ -187,7 +186,16 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity,
         prefixAddedDid
       );
+      expect(revokeDelegate).toBeTruthy();
+    });
 
+    it("Revoke delegation on RSK without prefix", async () => {
+      const prefixToAdd = "";
+      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
       expect(revokeDelegate).toBeTruthy();
     });
 
@@ -285,7 +293,16 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity,
         prefixAddedDid
       );
+      expect(revokeDelegate).toBeTruthy();
+    });
 
+    it("Revoke delegation on LACCHAIN without prefix", async () => {
+      const prefixToAdd = "";
+      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
       expect(revokeDelegate).toBeTruthy();
     });
 
@@ -307,7 +324,6 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity.did,
         prefixAddedDid
       );
-
       expect(validatedDelegate).toBeFalsy();
     });
 
@@ -380,6 +396,17 @@ describe("BlockchainManager Delegation", () => {
 
     it("Revoke delegation on BFA", async () => {
       const prefixToAdd = "bfa:";
+      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
+
+      expect(revokeDelegate).toBeTruthy();
+    });
+
+    it("Revoke delegation on BFA without prefix", async () => {
+      const prefixToAdd = "";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(
         issuerIdentity,

--- a/__tests__/delegate_test.js
+++ b/__tests__/delegate_test.js
@@ -135,7 +135,7 @@ describe("BlockchainManager Delegation", () => {
     });
   });
 
-  describe.only("On RSK should", () => {
+  describe("On RSK should", () => {
     const delegateIdentity = createIdentity();
 
     it("be able to addDelegate on RSK", async () => {
@@ -169,7 +169,7 @@ describe("BlockchainManager Delegation", () => {
       expect(validatedDelegate).toBeTruthy();
     });
 
-    it.skip("verify delegation on RSK", async () => {
+    it.skip("verify delegation on RSK witout", async () => {
       const prefixToAdd = "";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
@@ -189,7 +189,7 @@ describe("BlockchainManager Delegation", () => {
       expect(revokeDelegate).toBeTruthy();
     });
 
-    it.skip("Revoke delegation on RSK without prefix", async () => {
+    it("Revoke delegation on RSK without prefix", async () => {
       const prefixToAdd = "";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(

--- a/__tests__/delegate_test.js
+++ b/__tests__/delegate_test.js
@@ -135,7 +135,7 @@ describe("BlockchainManager Delegation", () => {
     });
   });
 
-  describe("On RSK should", () => {
+  describe.only("On RSK should", () => {
     const delegateIdentity = createIdentity();
 
     it("be able to addDelegate on RSK", async () => {
@@ -169,7 +169,7 @@ describe("BlockchainManager Delegation", () => {
       expect(validatedDelegate).toBeTruthy();
     });
 
-    it("verify delegation on RSK without prefix", async () => {
+    it.skip("verify delegation on RSK", async () => {
       const prefixToAdd = "";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
@@ -189,7 +189,7 @@ describe("BlockchainManager Delegation", () => {
       expect(revokeDelegate).toBeTruthy();
     });
 
-    it("Revoke delegation on RSK without prefix", async () => {
+    it.skip("Revoke delegation on RSK without prefix", async () => {
       const prefixToAdd = "";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(

--- a/__tests__/delegate_test.js
+++ b/__tests__/delegate_test.js
@@ -169,12 +169,10 @@ describe("BlockchainManager Delegation", () => {
       expect(validatedDelegate).toBeTruthy();
     });
 
-    it.skip("verify delegation on RSK witout", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
+    it("verify delegation on RSK without prefix", async () => {
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
       expect(validatedDelegate).toBeTruthy();
     });
@@ -186,17 +184,19 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity,
         prefixAddedDid
       );
-      expect(revokeDelegate).toBeTruthy();
+      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 
     it("Revoke delegation on RSK without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(
         issuerIdentity,
-        prefixAddedDid
+        delegateIdentity.did
       );
-      expect(revokeDelegate).toBeTruthy();
+      revokeDelegate.map(i => i.value && i.value.events && 
+        expect(parseInt(i.value.events.DIDDelegateChanged.returnValues.validTo - Date.now() / 1000))
+        .toBeLessThan(500)
+      );
     });
 
     it("Fail verification due to revoked delegation on RSK", async () => {
@@ -210,11 +210,9 @@ describe("BlockchainManager Delegation", () => {
     });
 
     it("Fail verification due to revoked delegation on RSK without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
       expect(validatedDelegate).toBeFalsy();
     });
@@ -232,13 +230,22 @@ describe("BlockchainManager Delegation", () => {
 
     it("Fail verification when delegation does not exists on RSK without prefix", async () => {
       const otherIdentity = createIdentity();
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        otherIdentity.did
       );
       expect(validatedDelegate).toBeFalsy();
+    });
+
+    it.skip("Fail revocation when delegation does not exists on any blockchain", async () => {
+      const otherIdentity = createIdentity();
+      const prefixToAdd = "rsk:";
+      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
+      expect(revokeDelegate.events).toBeUndefined();
     });
   });
 
@@ -277,11 +284,9 @@ describe("BlockchainManager Delegation", () => {
     });
 
     it("verify delegation on LACCHAIN without prefix", async () => {
-      const prefixToAdd = "lacchain:";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
       expect(validatedDelegate).toBeTruthy();
     });
@@ -293,17 +298,19 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity,
         prefixAddedDid
       );
-      expect(revokeDelegate).toBeTruthy();
+      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 
     it("Revoke delegation on LACCHAIN without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(
         issuerIdentity,
-        prefixAddedDid
+        delegateIdentity.did
       );
-      expect(revokeDelegate).toBeTruthy();
+      revokeDelegate.map(i => i.value && i.value.events && 
+        expect(parseInt(i.value.events.DIDDelegateChanged.returnValues.validTo - Date.now() / 1000))
+        .toBeLessThan(500)
+      );
     });
 
     it("Fail verification due to revoked delegation on LACCHAIN", async () => {
@@ -313,16 +320,13 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity.did,
         prefixAddedDid
       );
-
       expect(validatedDelegate).toBeFalsy();
     });
 
     it("Fail verification due to revoked delegation on LACCHAIN without prefix", async () => {
-      const prefixToAdd = "lacchain:";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
       expect(validatedDelegate).toBeFalsy();
     });
@@ -340,13 +344,22 @@ describe("BlockchainManager Delegation", () => {
 
     it("Fail verification when delegation does not exists on LACCHAIN without prefix", async () => {
       const otherIdentity = createIdentity();
-      const prefixToAdd = "lacchain:";
-      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        otherIdentity.did
       );
       expect(validatedDelegate).toBeFalsy();
+    });
+
+    it.skip("Fail revocation when delegation does not exists on any blockchain", async () => {
+      const otherIdentity = createIdentity();
+      const prefixToAdd = "lacchain:";
+      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
+      expect(revokeDelegate.events).toBeUndefined();
     });
   });
 
@@ -385,11 +398,9 @@ describe("BlockchainManager Delegation", () => {
     });
 
     it("verify delegation on BFA without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
       expect(validatedDelegate).toBeTruthy();
     });
@@ -401,19 +412,19 @@ describe("BlockchainManager Delegation", () => {
         issuerIdentity,
         prefixAddedDid
       );
-
-      expect(revokeDelegate).toBeTruthy();
+      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 
     it("Revoke delegation on BFA without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const revokeDelegate = await blockchainManager.revokeDelegate(
         issuerIdentity,
-        prefixAddedDid
+        delegateIdentity.did
       );
-
-      expect(revokeDelegate).toBeTruthy();
+      revokeDelegate.map(i => i.value && i.value.events && 
+        expect(parseInt(i.value.events.DIDDelegateChanged.returnValues.validTo - Date.now() / 1000))
+        .toBeLessThan(500)
+      );
     });
 
     it("Fail verification due to revoked delegation on BFA", async () => {
@@ -428,11 +439,9 @@ describe("BlockchainManager Delegation", () => {
     });
 
     it("Fail verification due to revoked delegation on BFA without prefix", async () => {
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        delegateIdentity.did
       );
 
       expect(validatedDelegate).toBeFalsy();
@@ -449,15 +458,24 @@ describe("BlockchainManager Delegation", () => {
       expect(validatedDelegate).toBeFalsy();
     });
 
-    it("Fail verification when delegation does not exists on BFA", async () => {
+    it("Fail verification when delegation does not exists on BFA without prefix", async () => {
       const otherIdentity = createIdentity();
-      const prefixToAdd = "";
-      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
       const validatedDelegate = await blockchainManager.validateDelegate(
         issuerIdentity.did,
-        prefixAddedDid
+        otherIdentity.did
       );
       expect(validatedDelegate).toBeFalsy();
+    });
+
+    it.skip("Fail revocation when delegation does not exists on any blockchain", async () => {
+      const otherIdentity = createIdentity();
+      const prefixToAdd = "bfa:";
+      const prefixAddedDid = addPrefix(prefixToAdd, otherIdentity.did);
+      const revokeDelegate = await blockchainManager.revokeDelegate(
+        issuerIdentity,
+        prefixAddedDid
+      );
+      expect(revokeDelegate.events).toBeUndefined();
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "dotenv": "^8.2.0",
         "eslint": "^7.13.0",
         "jest": "^26.4.2",
-        "typescript": "^4.0.5"
+        "typescript": "^4.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -12165,9 +12165,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23027,9 +23027,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.13.0",
     "jest": "^26.4.2",
-    "typescript": "^4.0.5"
+    "typescript": "^4.4.3"
   },
   "scripts": {
+    "test2": "jest --runInBand",
     "test": "jest && coveralls < coverage/lcov.info",
     "build": "tsc",
     "typeCheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "^4.4.3"
   },
   "scripts": {
-    "test2": "jest --runInBand",
+    "test2": "jest",
     "test": "jest && coveralls < coverage/lcov.info",
     "build": "tsc",
     "typeCheck": "tsc --noEmit",

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -453,9 +453,7 @@ export class BlockchainManager {
    * @param {Identity} issuerCredentials 
    */
   private async revokeOnBlockchain(blockchainToConnect: NetworkConfig, delegatedDID: string, issuerCredentials: Identity) {
-    const sourceAddress = BlockchainManager.getDidAddress(
-      issuerCredentials.did
-    );
+    const sourceAddress = BlockchainManager.getDidAddress(issuerCredentials.did);
     const targetAddress = BlockchainManager.getDidAddress(delegatedDID);
 
     const provider = new Web3.providers.HttpProvider(
@@ -463,9 +461,7 @@ export class BlockchainManager {
     );
     const web3 = new Web3(provider);
 
-    const options: Options = {
-      from: sourceAddress,
-    };
+    const options: Options = { from: sourceAddress };
 
     const contract = BlockchainManager.getDidContract(
       options,
@@ -527,7 +523,7 @@ export class BlockchainManager {
         issuerCredentials
       );
     });
-    return Promise.any(revoke);
+    return Promise.allSettled(revoke);
   }
 
   /**

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -242,6 +242,7 @@ export class BlockchainManager {
     web3.eth.accounts.wallet.remove(account.address);
     return delegateMethodSent;
   }
+
   /**
    * Given a blockchain and an issuer, validate the delegate
    * @param {NetworkConfig} blockchainToConnect 
@@ -446,25 +447,21 @@ export class BlockchainManager {
   }
 
   /**
-   * Revoke delegation
-   * @param {Identity}  issuerCredentials
-   * @param {string}  delegatedDID
+   * Given a blockchain revoke a delegate
+   * @param {NetworkConfig} blockchainToConnect 
+   * @param {string} delegatedDID 
+   * @param {Identity} issuerCredentials 
    */
-  async revokeDelegate(issuerCredentials, delegatedDID) {
-    const blockchainToConnect = blockChainSelector(
-      this.config.providerConfig.networks,
-      delegatedDID
+  private async revokeOnBlockchain(blockchainToConnect: NetworkConfig, delegatedDID: string, issuerCredentials: Identity) {
+    const sourceAddress = BlockchainManager.getDidAddress(
+      issuerCredentials.did
     );
+    const targetAddress = BlockchainManager.getDidAddress(delegatedDID);
 
     const provider = new Web3.providers.HttpProvider(
       blockchainToConnect.provider
     );
     const web3 = new Web3(provider);
-
-    const sourceAddress = BlockchainManager.getDidAddress(
-      issuerCredentials.did
-    );
-    const targetAddress = BlockchainManager.getDidAddress(delegatedDID);
 
     const options: Options = {
       from: sourceAddress,
@@ -499,7 +496,38 @@ export class BlockchainManager {
       revokeMethodSent = await this.revokeDelegate(issuerCredentials, delegatedDID)
     }
     web3.eth.accounts.wallet.remove(account.address);
-    return revokeMethodSent;
+    return revokeMethodSent;    
+  }
+
+  /**
+   * Revoke delegation
+   * @param {Identity}  issuerCredentials
+   * @param {string}  delegatedDID
+   */
+  async revokeDelegate(issuerCredentials, delegatedDID) {
+    const blockchain = BlockchainManager.getDidBlockchain(delegatedDID);
+
+    if (blockchain) {
+      const blockchainToConnect = blockChainSelector(
+        this.config.providerConfig.networks,
+        delegatedDID
+      );
+      return this.revokeOnBlockchain(blockchainToConnect, delegatedDID, issuerCredentials);
+    }
+
+    const revoke = this.config.providerConfig.networks.map(network => {
+      const blockchainToConnect: NetworkConfig = {
+        provider: network.rpcUrl,
+        address: network.registry,
+        name: network.name,
+      };
+      return this.revokeOnBlockchain(
+        blockchainToConnect, 
+        delegatedDID, 
+        issuerCredentials
+      );
+    });
+    return Promise.any(revoke);
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "inlineSourceMap": true,
         "module": "commonjs",
-        "target": "es2015",
+        "target": "es2021",
         "declaration": true,
         "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
         "outDir": "./dist",


### PR DESCRIPTION
- Se actualiza el metodo revokeDelegate para que acepte dids sin prefijos y busque la delegación sobre todas las blockchain en este caso.