### PR TITLE
Fix/update interface on single blockchain operations

### DIFF
--- a/__tests__/delegate_test.js
+++ b/__tests__/delegate_test.js
@@ -155,9 +155,10 @@ describe("BlockchainManager Delegation", () => {
 
     it("be able to addDelegate on RSK", async () => {
       const prefixToAdd = "rsk:";
-      const tx = await addDelegation(prefixToAdd, delegateIdentity);
-      expect(tx).toBeDefined();
-      expect(tx.status).toBeTruthy();
+      const response = await addDelegation(prefixToAdd, delegateIdentity);
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('rsk');
+      expect(response[0].value).toBeDefined();
     });
 
     it("be able to addDelegate 3 times simultaneously on RSK", async () => {
@@ -169,8 +170,9 @@ describe("BlockchainManager Delegation", () => {
 
       const delegtions = await Promise.all(delegateTxs);
       for (let i = 0; i < 3; i++) {
-        expect(delegtions[i]).toBeDefined();
-        expect(delegtions[i].status).toBeTruthy();
+        expect(delegtions[i][0].status).toBe('fulfilled');;
+        expect(delegtions[i][0].network).toBe('rsk');
+        expect(delegtions[i][0].value).toBeDefined();
       }
     });
 
@@ -187,11 +189,16 @@ describe("BlockchainManager Delegation", () => {
     it("Revoke delegation on RSK", async () => {
       const prefixToAdd = "rsk:";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
-      const revokeDelegate = await blockchainManager.revokeDelegate(
+      const response = await blockchainManager.revokeDelegate(
         issuerIdentity,
         prefixAddedDid
       );
-      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('rsk');
+      expect(response[0].value).toBeDefined();
+      
+      const { validTo } = response[0].value.events.DIDDelegateChanged.returnValues;
       expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 
@@ -222,9 +229,10 @@ describe("BlockchainManager Delegation", () => {
 
     it("be able to addDelegate on LACCHAIN", async () => {
       const prefixToAdd = "lacchain:";
-      const tx = await addDelegation(prefixToAdd, delegateIdentity);
-      expect(tx).toBeDefined();
-      expect(tx.status).toBeTruthy();
+      const response = await addDelegation(prefixToAdd, delegateIdentity);
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('lacchain');
+      expect(response[0].value).toBeDefined();
     });
 
     it("be able to addDelegate 3 times simultaneously on LACCHAIN", async () => {
@@ -236,8 +244,9 @@ describe("BlockchainManager Delegation", () => {
 
       const delegtions = await Promise.all(delegateTxs);
       for (let i = 0; i < 3; i++) {
-        expect(delegtions[i]).toBeDefined();
-        expect(delegtions[i].status).toBeTruthy();
+        expect(delegtions[i][0].status).toBe('fulfilled');;
+        expect(delegtions[i][0].network).toBe('lacchain');
+        expect(delegtions[i][0].network).toBeDefined();
       }
     });
 
@@ -254,11 +263,16 @@ describe("BlockchainManager Delegation", () => {
     it("Revoke delegation on LACCHAIN", async () => {
       const prefixToAdd = "lacchain:";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
-      const revokeDelegate = await blockchainManager.revokeDelegate(
+      const response = await blockchainManager.revokeDelegate(
         issuerIdentity,
         prefixAddedDid
       );
-      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('lacchain');
+      expect(response[0].value).toBeDefined();
+      
+      const { validTo } = response[0].value.events.DIDDelegateChanged.returnValues;
       expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 
@@ -289,9 +303,10 @@ describe("BlockchainManager Delegation", () => {
 
     it("be able to addDelegate on BFA", async () => {
       const prefixToAdd = "bfa:";
-      const tx = await addDelegation(prefixToAdd, delegateIdentity);
-      expect(tx).toBeDefined();
-      expect(tx.status).toBeTruthy();
+      const response = await addDelegation(prefixToAdd, delegateIdentity);
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('bfa');
+      expect(response[0].value).toBeDefined();
     });
 
     it("be able to addDelegate 3 times simultaneously on BFA", async () => {
@@ -303,8 +318,9 @@ describe("BlockchainManager Delegation", () => {
 
       const delegtions = await Promise.all(delegateTxs);
       for (let i = 0; i < 3; i++) {
-        expect(delegtions[i]).toBeDefined();
-        expect(delegtions[i].status).toBeTruthy();
+        expect(delegtions[i][0].status).toBe('fulfilled');;
+        expect(delegtions[i][0].network).toBe('bfa');
+        expect(delegtions[i][0].network).toBeDefined();
       }
     });
 
@@ -321,11 +337,16 @@ describe("BlockchainManager Delegation", () => {
     it("Revoke delegation on BFA", async () => {
       const prefixToAdd = "bfa:";
       const prefixAddedDid = addPrefix(prefixToAdd, delegateIdentity.did);
-      const revokeDelegate = await blockchainManager.revokeDelegate(
+      const response = await blockchainManager.revokeDelegate(
         issuerIdentity,
         prefixAddedDid
       );
-      const { validTo } = revokeDelegate.events.DIDDelegateChanged.returnValues;
+      
+      expect(response[0].status).toBe('fulfilled');
+      expect(response[0].network).toBe('bfa');
+      expect(response[0].value).toBeDefined();
+      
+      const { validTo } = response[0].value.events.DIDDelegateChanged.returnValues;
       expect(parseInt(validTo) - Date.now() / 1000).toBeLessThan(500);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@proyecto-didi/didi-blockchain-manager",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@proyecto-didi/didi-blockchain-manager",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "dependencies": {
         "did-jwt": "4.5.1",
         "did-jwt-vc": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proyecto-didi/didi-blockchain-manager",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "dependencies": {
     "did-jwt": "4.5.1",
     "did-jwt-vc": "0.1.3",

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -90,7 +90,7 @@ interface NetworkConfig {
   name: string,
 }
 
-interface addDelegateResponse {
+interface OperationResponse {
   status: 'fulfilled' | 'rejected',
   network: string,
   value: any
@@ -275,7 +275,7 @@ export class BlockchainManager {
    * @param {string}  delegateDID
    * @param {string}  validity
    */
-  async addDelegate(identity: Identity, delegateDID: string, validity: string): Promise<addDelegateResponse[]> {
+  async addDelegate(identity: Identity, delegateDID: string, validity: string): Promise<OperationResponse[]> {
     const blockchain = BlockchainManager.getDidBlockchain(delegateDID);
 
     if (blockchain) {
@@ -562,7 +562,7 @@ export class BlockchainManager {
    * @param {Identity}  issuerCredentials
    * @param {string}  delegatedDID
    */
-  async revokeDelegate(issuerCredentials, delegatedDID) {
+  async revokeDelegate(issuerCredentials, delegatedDID): Promise<OperationResponse[]> {
     const blockchain = BlockchainManager.getDidBlockchain(delegatedDID);
 
     if (blockchain) {
@@ -570,7 +570,9 @@ export class BlockchainManager {
         this.config.providerConfig.networks,
         delegatedDID
       );
-      return this.revokeOnBlockchain(blockchainToConnect, delegatedDID, issuerCredentials);
+      const revoke: any = await Promise.allSettled([this.revokeOnBlockchain(blockchainToConnect, delegatedDID, issuerCredentials)])
+      revoke[0].network = blockchainToConnect.name;
+      return revoke;
     }
 
     const validNetworks = this.config.providerConfig.networks.filter(({ name }) => !!name);

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -11,7 +11,7 @@ const EthrDID = require("ethr-did");
 const blockChainSelector = (
   networkConfig: { name: string; rpcUrl: string; registry: string }[],
   did: string
-) => {
+): NetworkConfig => {
   let routerCharPos = -1,
     index = -1,
     i = 1;
@@ -308,7 +308,7 @@ export class BlockchainManager {
    * @param {String} identityAddr 
    * @param {String} delegateAddr 
    */
-  private async validateOnBlockchains(blockchainToConnect: any, identityAddr: string, delegateAddr: string) {
+  private async validateOnBlockchain(blockchainToConnect: NetworkConfig, identityAddr: string, delegateAddr: string) {
     const provider = new Web3.providers.HttpProvider(
       blockchainToConnect.provider
     );
@@ -346,7 +346,7 @@ export class BlockchainManager {
         this.config.providerConfig.networks,
         delegateDID
       );
-      return this.validateOnBlockchains(blockchainToConnect, identityAddr, delegateAddr);
+      return this.validateOnBlockchain(blockchainToConnect, identityAddr, delegateAddr);
     };
 
     const validations = this.config.providerConfig.networks.map(network => {
@@ -355,7 +355,7 @@ export class BlockchainManager {
         address: network.registry,
         name: network.name,
       };
-      return this.validateOnBlockchains(
+      return this.validateOnBlockchain(
         blockchainToConnect, 
         identityAddr, 
         delegateAddr
@@ -566,7 +566,7 @@ export class BlockchainManager {
     const blockchain = BlockchainManager.getDidBlockchain(delegatedDID);
 
     if (blockchain) {
-      const blockchainToConnect = blockChainSelector(
+      const blockchainToConnect: NetworkConfig = blockChainSelector(
         this.config.providerConfig.networks,
         delegatedDID
       );

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -149,7 +149,7 @@ export class BlockchainManager {
   
   /**
    * 
-   * @param {string } did Did to get the blockchain name from
+   * @param {string} did Did to get the blockchain name from
    */
   static getDidBlockchain(did: string) {
     const didAsArray = did.split(":");
@@ -160,8 +160,8 @@ export class BlockchainManager {
   /**
    * Add a blockchain beofre the ethereum address. Throws if already contains
    * a blockchain. did:ethr:0x123 => did:ethr:rinkeby:0x123
-   * @param did Did to add the blockchain
-   * @param blockchain Blockchain to add
+   * @param {string} did Did to add the blockchain
+   * @param {string} blockchain Blockchain to add
    */
   static addBlockchainToDid(did: string, blockchain: string) {
     const didAsArray = did.split(":");
@@ -171,8 +171,17 @@ export class BlockchainManager {
     return didAsArray.join(':');
   } 
 
-  /** Compare dids
-    */
+  /**
+   * Compare two dids DIDs. A DIDI without netowors is equal to a DID with network and
+   * same address. Two DIDs with same netork and different address are different. Ex:
+   * did:ethr:net:0x123 == did:ethr:0x123
+   * did:ethr:net1:0x123 != did:ethr:net2:0x123
+   * did:ethr:net:0x123 != did:ethr:net:0x124
+   * did:ethr:0x123 != did:ethr:0x124
+   * did:ethr:net1:0x123 != did:ethr:net2:0x124
+   * @param {string} did1 
+   * @param {string} did2 
+   */
   static compareDid(did1: string, did2:string){
     const didAddress1=BlockchainManager.getDidAddress(did1);
     const didAddress2=BlockchainManager.getDidAddress(did2);

--- a/src/BlockchainManager.ts
+++ b/src/BlockchainManager.ts
@@ -90,6 +90,12 @@ interface NetworkConfig {
   name: string,
 }
 
+interface addDelegateResponse {
+  status: 'fulfilled' | 'rejected',
+  network: string,
+  value: any
+}
+
 export class BlockchainManager {
   config: BlockchainManagerConfig;
   didResolver: Resolver;
@@ -269,7 +275,7 @@ export class BlockchainManager {
    * @param {string}  delegateDID
    * @param {string}  validity
    */
-  async addDelegate(identity: Identity, delegateDID: string, validity: string) {
+  async addDelegate(identity: Identity, delegateDID: string, validity: string): Promise<addDelegateResponse[]> {
     const blockchain = BlockchainManager.getDidBlockchain(delegateDID);
 
     if (blockchain) {
@@ -277,7 +283,9 @@ export class BlockchainManager {
         this.config.providerConfig.networks,
         delegateDID
       );
-      return this.delegateOnBlockchain(blockchainToConnect, identity, delegateDID, validity);
+      const delegations: any = await Promise.allSettled([this.delegateOnBlockchain(blockchainToConnect, identity, delegateDID, validity)]);  
+      delegations[0].network = blockchainToConnect.name;
+      return delegations;
     }
 
     const validNetworks = this.config.providerConfig.networks.filter(({ name }) => !!name);


### PR DESCRIPTION
- Update en la interfaz de la respuesta de los métodos. Ahora es la misma respuesta sin importar se la operación se realiza en una blockchain o varias.
- Mejoras de documentación
- Versión v2.0.0-rc.3

Travis falló por timeout, no es por problemas de código